### PR TITLE
Closes #28. Rename dev auth image. Keep node_modules inside container only.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM mhart/alpine-node:6.11.0
+FROM mhart/alpine-node:8.5
 
 RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-ADD package.json /usr/src/app
-RUN npm i
 ADD . /usr/src/app
+WORKDIR /usr/src/app
+RUN npm i
+
 EXPOSE 3000
 EXPOSE 4000
 CMD npm start

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:6.11.0
+FROM mhart/alpine-node:8.5
 
 RUN mkdir -p /usr/src/app
 ADD . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -28,49 +28,29 @@ This session mechanism is also used to invalidate tokens. Removing session key f
 ## API Endpoints
 For more information, see [API Blueprint](./apiary.apib)
 
-1. `/user` POST - create a new user
-2. `/user/{login}` DELETE - delete specific user
-3. `/auth/` POST - log user in
-4. `/auth/verify` POST - verify the given token
-5. `/auth/logout` POST - logout user
+1. `/tenant` POST - register a tenant.
+1. `/tenant/login` POST - login a tenant.
+1. `/tenant/logout` POST - logout a tenant.
+1. `/tenant/verify` POST - verify tenant's JWT token.
+1. `/user` POST - create a new user.
+1. `/user/{login}` DELETE - delete specific user.
+1. `/auth/` POST - log user in.
+1. `/auth/verify` POST - verify the given token.
+1. `/auth/logout` POST - logout user.
 
+## How to build
 
-## API Security Checklist
-Checklist of the most important security countermeasures when designing, testing, and releasing your API.
+### For development
 
-------------------------------------------------------------------------------
-### Authentication
-- [x] Don't use `Basic Auth` Use standard authentication (e.g. JWT, OAuth).
-- [x] Don't reinvent the wheel in `Authentication`, `token generating`, `password storing` use the standards.
+1. Clone this repo.
+1. Run `docker-compose build --no-cache`.
+1. Start development containers: `docker-compose up -d`.
+1. If you want to update/install dependency run: `docker-compose exec auth npm i some-dep`.
+IMPORTANT: To keep your changes in container you have to commit it: `docker commit registry.jincor.com/backend/auth-develop:latest`.
+1. To run tests run `docker-compose exec auth npm test`
 
-#### JWT (JSON Web Token)
-- [x] Use random complicated key (`JWT Secret`) to make brute forcing token very hard.
-- [x] Don't extract the algorithm from the payload. Force algorithm in the backend (`HS256` or `RS256`). 
-- [x] Make token expiration (`TTL`, `RTTL`) as short as possible.
-- [x] Don't store sensitive data in the JWT payload, it can be decoded [easily](https://jwt.io/#debugger-io).
-
-### Access
-- [x] Limit requests (Throttling) to avoid DDoS / Bruteforce attacks.
-- [x] Use HTTPS on server side to avoid MITM (Man In The Middle Attack).
-- [x] Use `HSTS` header with SSL to avoid SSL Strip attack.
-
-### Input
-- [x] Use proper HTTP method according to operation , `GET (read)`, `POST (create)`, `PUT (replace/update)` and `DELETE (to delete a record)`.
-- [x] Validate `content-type` on request Accept header ( Content Negotiation ) to allow only your supported format (e.g. `application/xml` , `application/json` ... etc) and respond with `406 Not Acceptable` response if not matched.
-- [x] Validate `content-type` of posted data as you accept (e.g. `application/x-www-form-urlencoded` , `multipart/form-data ,application/json` ... etc ).
-- [ ] Validate User input to avoid common vulnerabilities (e.g. `XSS`, `SQL-Injection` , `Remote Code Execution` ... etc).
-- [x] Don't use any sensitive data ( `credentials` , `Passwords`, `security tokens`, or `API keys`) in the URL, but use standard Authorization header.
-
-### Processing
-- [ ] Check if all endpoint protected behind the authentication to avoid broken authentication.
-- [x] Don't use auto increment id's use `UUID` instead.
-- [ ] Do not forget to turn the DEBUG mode OFF.
-
-### Output
-- [x] Send `X-Content-Type-Options: nosniff` header.
-- [x] Send `X-Frame-Options: deny` header.
-- [x] Send `Content-Security-Policy: default-src 'none'` header.
-- [x] Remove fingerprinting headers - `X-Powered-By`, `Server`, `X-AspNet-Version` etc.
-- [x] Force `content-type` for your response , if you return `application/json` then your response `content-type` is `application/json`.
-- [x] Don't return sensitive data like `credentials` , `Passwords`, `security tokens`.
-- [x] Return the proper status code according to the operation completed. (e.g. `200 OK` , `400 Bad Request` , `401 Unauthorized`, `405 Method Not Allowed` ... etc).
+### For production
+1. Clone this repo.
+1. Run `docker-compose -f docker-compose.prod.yml build --no-cache`.
+1. To start prod containers: `docker-compose -f docker-compose.prod.yml up -d`.
+1. Push to registry: `docker push registry.jincor.com/backend/auth:latest`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   auth:
-    image: registry.jincor.com/backend/auth:latest
+    image: registry.jincor.com/backend/auth-develop:latest
     build:
         context: ./
         dockerfile: Dockerfile
@@ -17,6 +17,7 @@ services:
       - "4000"
     volumes:
       - ./:/usr/src/app
+      - /usr/src/app/node_modules
     links:
       - redis
   redis:


### PR DESCRIPTION
Now you don't have to run npm i on your host machine. Moreover you might not have npm at all anymore. Everthing might be done in docker now.